### PR TITLE
Update Toggle Recording on iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,15 +1,20 @@
 PODS:
-  - GruveoSDK (1.1.3):
-    - GruveoWebRTC (~> 1.59)
-  - GruveoWebRTC (1.59.19.1)
+  - GruveoSDK (1.4):
+    - GruveoWebRTC (~> 1.65.25.2)
+  - GruveoWebRTC (1.65.25.2)
 
 DEPENDENCIES:
   - GruveoSDK
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - GruveoSDK
+    - GruveoWebRTC
+
 SPEC CHECKSUMS:
-  GruveoSDK: c817633cc00cc75c6229acdc0727dae791b1c129
-  GruveoWebRTC: e9024a8a9092c18907c3ad566374ac4ccab0b0e2
+  GruveoSDK: d46b93ad50411f5bd955cec0bb5242fbcc910289
+  GruveoWebRTC: 588718919dead4762a3b5cce8c37f6032d64157a
 
 PODFILE CHECKSUM: 6a8dbad501ed8e3961d9dddec7933740034c9d0d
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.6.1

--- a/ios/RNGruveo.m
+++ b/ios/RNGruveo.m
@@ -156,10 +156,11 @@ RCT_EXPORT_METHOD(toggleRoomLock:(BOOL)enable)
 }
 
 // Starts or stops call recording.
-RCT_EXPORT_METHOD(toggleRecording:(BOOL)enable)
+RCT_EXPORT_METHOD(toggleRecording:(BOOL)enable withLayout:(int)layout)
 {
     dispatch_sync(dispatch_get_main_queue(), ^{
-        [GruveoCallManager toggleRecording:enable];
+        GruveoCallRecordingLayout *gruveoRecordingLayout = layout == 0 ? GruveoCallRecordingLayoutMaximized : GruveoCallRecordingLayoutTiled;
+        [GruveoCallManager toggleRecording:enable withLayout:gruveoRecordingLayout];
     });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gruveo",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "email": "umar.nizamani@gmail.com"
   },
   "contributors": [
-    "Ruben Weijers" 
+    "Ruben Weijers",
+    "Muhammad Yusuf" 
   ],
   "homepage": "https://github.com/senseobservationsystems/react-native-gruveo",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "contributors": [
     "Ruben Weijers",
-    "Muhammad Yusuf" 
+    "Muhammad Yusuf"
   ],
   "homepage": "https://github.com/senseobservationsystems/react-native-gruveo",
   "bugs": {


### PR DESCRIPTION
On previous [PR](https://github.com/senseobservationsystems/react-native-gruveo/pull/1) I only updated the native method of toggle recording on Android and missed the iOS part. This PR to update the toggle recording native method on iOS part.