### PR TITLE
Update Gradle and Add Kotlin Dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,54 @@
 buildscript {
+  ext.kotlin_version = "1.3.31"
+  repositories {
+    jcenter()
+    maven {
+      url 'https://maven.google.com/'
+      name 'Google'
+    }
+  }
+
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.4.1'
+
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
+  }
+}
+
+apply plugin: 'com.android.library'
+
+def DEFAULT_COMPILE_SDK_VERSION = 26
+def DEFAULT_BUILD_TOOLS_VERSION = "26.0.3"
+def DEFAULT_TARGET_SDK_VERSION  = 22
+def DEFAULT_MIN_SDK_VERSION     = 17
+def DEFAULT_GRUVEO_SDK_VERSION  = "0.6.5"
+
+android {
+  compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+  buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+
+  defaultConfig {
+    minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
+    targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+    versionCode 1
+    versionName "1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+    maven { url "https://jitpack.io" }
+    maven {
+      url 'https://maven.google.com/'
+      name 'Google'
+    }
+}
+buildscript {
   repositories {
     jcenter()
     maven {
@@ -36,13 +86,13 @@ android {
 }
 
 repositories {
-    mavenCentral()
-    jcenter()
-    maven { url "https://jitpack.io" }
-    maven {
-      url 'https://maven.google.com/'
-      name 'Google'
-    }
+  mavenCentral()
+  jcenter()
+  maven { url "https://jitpack.io" }
+  maven {
+    url 'https://maven.google.com/'
+    name 'Google'
+  }
 }
 
 dependencies {
@@ -50,4 +100,12 @@ dependencies {
 
   compile 'com.facebook.react:react-native:+'
   compile "org.bitbucket.gruveo:gruveo-sdk-android:${gruveoSdkVersion}"
+}
+
+dependencies {
+  def gruveoSdkVersion = project.hasProperty('gruveoSdkVersion') ? project.gruveoSdkVersion : DEFAULT_GRUVEO_SDK_VERSION
+
+  compile 'com.facebook.react:react-native:+'
+  compile "org.[bitbucket.gruveo:gruveo-sdk-android:${gruveoSdkVersion}"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,39 +62,6 @@ buildscript {
   }
 }
 
-apply plugin: 'com.android.library'
-
-def DEFAULT_COMPILE_SDK_VERSION = 26
-def DEFAULT_BUILD_TOOLS_VERSION = "26.0.3"
-def DEFAULT_TARGET_SDK_VERSION  = 22
-def DEFAULT_MIN_SDK_VERSION     = 17
-def DEFAULT_GRUVEO_SDK_VERSION  = "0.6.5"
-
-android {
-  compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
-
-  defaultConfig {
-    minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
-    targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
-    versionCode 1
-    versionName "1.0"
-  }
-  lintOptions {
-    abortOnError false
-  }
-}
-
-repositories {
-  mavenCentral()
-  jcenter()
-  maven { url "https://jitpack.io" }
-  maven {
-    url 'https://maven.google.com/'
-    name 'Google'
-  }
-}
-
 dependencies {
   def gruveoSdkVersion = project.hasProperty('gruveoSdkVersion') ? project.gruveoSdkVersion : DEFAULT_GRUVEO_SDK_VERSION
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,26 +48,6 @@ repositories {
       name 'Google'
     }
 }
-buildscript {
-  repositories {
-    jcenter()
-    maven {
-      url 'https://maven.google.com/'
-      name 'Google'
-    }
-  }
-
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
-  }
-}
-
-dependencies {
-  def gruveoSdkVersion = project.hasProperty('gruveoSdkVersion') ? project.gruveoSdkVersion : DEFAULT_GRUVEO_SDK_VERSION
-
-  compile 'com.facebook.react:react-native:+'
-  compile "org.bitbucket.gruveo:gruveo-sdk-android:${gruveoSdkVersion}"
-}
 
 dependencies {
   def gruveoSdkVersion = project.hasProperty('gruveoSdkVersion') ? project.gruveoSdkVersion : DEFAULT_GRUVEO_SDK_VERSION

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,6 +73,6 @@ dependencies {
   def gruveoSdkVersion = project.hasProperty('gruveoSdkVersion') ? project.gruveoSdkVersion : DEFAULT_GRUVEO_SDK_VERSION
 
   compile 'com.facebook.react:react-native:+'
-  compile "org.[bitbucket.gruveo:gruveo-sdk-android:${gruveoSdkVersion}"
+  compile "org.bitbucket.gruveo:gruveo-sdk-android:${gruveoSdkVersion}"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
When building release version using last version of react-native-gruveo (v1.0.8), we faced some build error. Turned out it's because we need to add Kotlin dependency and update gradle version to comply new version of Gruveo Android SDK (v0.6.5). This PR is to solve that problem.